### PR TITLE
Build fixes

### DIFF
--- a/.build/build-template.ini
+++ b/.build/build-template.ini
@@ -1,8 +1,9 @@
 # configuration file for build.py
-
 # A hash symbol (#) at the beginning of a line prevents a line from being executed.
-# if Zip7 points to 7z.exe, the script archive will be compressed
 
-#GitExe = r"\git.exe"
-#SpaceEngineers = r"\Steam\SteamApps\common\SpaceEngineers"
-#Zip7 = r"\7-Zip\7z.exe"
+# Provide absolute paths to required files
+SpaceEngineers = r"C:\Program Files (x86)\Steam\steamapps\common\SpaceEngineers"
+GitExe = r"C:\path\to\git.exe"
+
+# if Zip7 points to 7z.exe, the script archive will be compressed
+# Zip7 = r"C:\Program Files\7-Zip\7z.exe"

--- a/.build/build.py
+++ b/.build/build.py
@@ -198,7 +198,7 @@ os.system('start /D "' + source + '" /WAIT cmd.exe /C ' + command)
 
 if not "release" in str.lower(build):
 	SpaceEngineers = SpaceBin + '\SpaceEngineers.exe'
-	os.system('start /D ' + SpaceBin + ' cmd /c"' + SpaceEngineers)
+	os.system('start /D "' + SpaceBin + '" cmd /c "' + SpaceEngineers + '"')
 
 #    Pack Archive
 


### PR DESCRIPTION
* update build template with default paths and abs note 
  * informs users that paths must be absolute
  * provides initial paths matching default installs on a vanilla windows file system
* wrap SE path w quotes in build
  * fixes build.py#201 throws an uncaptured error when run on a path with spaces in it 