### PR TITLE
find mod component helper

### DIFF
--- a/Scripts/ARMS.csproj
+++ b/Scripts/ARMS.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Utility\Extensions\VectorExtensions.cs" />
     <Compile Include="Utility\FastResourceLock.cs" />
     <Compile Include="Utility\Globals.cs" />
+    <Compile Include="Utility\Mods.cs" />
     <Compile Include="Utility\Lazy.cs" />
     <Compile Include="Utility\LineSegment.cs" />
     <Compile Include="Utility\LineSegmentD.cs" />

--- a/Scripts/Update/DisableNotifyDownload.cs
+++ b/Scripts/Update/DisableNotifyDownload.cs
@@ -18,47 +18,13 @@ namespace Rynchodon.Update
 				if (mod.PublishedFileId == 363880940uL || mod.Name == "ARMS")
 				{
 					Logger.DebugLog("ARMS mod: FriendlyName: " + mod.FriendlyName + ", Name: " + mod.Name + ", Published ID: " + mod.PublishedFileId);
-					string assemblyName = mod.Name + "_SteamShipped, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
-
-					// Type.GetType(string typeName) with the fully qualified name doesn't seem to work, maybe it's something to do with CodeDOM
-					foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-						if (assembly.FullName == assemblyName)
-						{
-							string typeName = "SteamShipped.Notify";
-							Type notify = assembly.GetType(typeName);
-							if (notify == null)
-							{
-								Logger.AlwaysLog("Failed to get type from assembly. Assembly: " + assembly.FullName + ", Type: " + typeName, Logger.severity.ERROR);
-								return;
-							}
-							else
-							{
-								CachingDictionary<Type, MySessionComponentBase> m_sessionComponents = (CachingDictionary<Type, MySessionComponentBase>)
-									typeof(MySession).GetField("m_sessionComponents", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(MySession.Static);
-								if (m_sessionComponents == null)
-								{
-									Logger.AlwaysLog("Failed to get m_sessionComponents", Logger.severity.ERROR);
-									return;
-								}
-								else
-								{
-									MySessionComponentBase notifyObj;
-									if (!m_sessionComponents.TryGetValue(notify, out notifyObj))
-									{
-										Logger.DebugLog("Failed to get MySessionComponentBase", Logger.severity.TRACE);
-										// there can be more than one assembly with the right name
-										continue;
-									}
-									else
-										notifyObj.GetType().GetField("HasNotified").SetValue(notifyObj, true);
-								}
-							}
-
-							Logger.DebugLog("Unregistered " + typeName);
-							return;
-						}
-
-					Logger.AlwaysLog("Failed to find assembly: " + assemblyName, Logger.severity.ERROR);
+					MySessionComponentBase component = Mods.FindModSessionComponent(mod.Name, "SteamShipped", "Notify");
+					if (component == null)
+					{
+						Logger.AlwaysLog($"Failed to find Session Component.", Logger.severity.ERROR);
+						return;
+					}
+					component.GetType().GetField("HasNotified").SetValue(component, true);
 					return;
 				}
 

--- a/Scripts/Utility/Mods.cs
+++ b/Scripts/Utility/Mods.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Sandbox.Game.World;
+using VRage.Collections;
+using VRage.Game.Components;
+
+namespace Rynchodon
+{
+	public static class Mods
+	{
+		public static MySessionComponentBase FindModSessionComponent(string modName, string modProject, string componentClassName)
+		{
+			string assemblyName = $"{modName}_{modProject}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+			string typeName = $"{modProject}.{componentClassName}";
+
+			CachingDictionary<Type, MySessionComponentBase> sessionComponents = (CachingDictionary<Type, MySessionComponentBase>)
+				typeof(MySession).GetField("m_sessionComponents", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(MySession.Static);
+			if (sessionComponents == null)
+			{
+				Logger.AlwaysLog("Failed to get m_sessionComponents", Logger.severity.ERROR);
+				return null;
+			}
+
+			// Type.GetType(string typeName) with the fully qualified name doesn't seem to work, maybe it's something to do with CodeDOM
+			// there can be more than one assembly with the right name
+			foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName == assemblyName))
+			{
+					Type componentType = assembly.GetType(typeName);
+					if (componentType == null)
+					{
+						Logger.DebugLog($"Failed to get type from assembly. Assembly: {assemblyName}, Type: {typeName}", Logger.severity.TRACE);
+						continue;
+					}
+
+					MySessionComponentBase component;
+					if (!sessionComponents.TryGetValue(componentType, out component))
+					{
+						Logger.DebugLog($"Failed to get MySessionComponentBase. Assembly: {assemblyName}, Type: {typeName}", Logger.severity.TRACE);
+						continue;
+					}
+
+					return component;
+			}
+
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
`DisableNotifyDownload` contains code that finds a session component given a mod and assembly/type names. This PR moves it to a helper so other mods can make use of the same logic.