### PR TITLE
adj FindSessionComponent for scripts folder name

### DIFF
--- a/Scripts/Update/DisableNotifyDownload.cs
+++ b/Scripts/Update/DisableNotifyDownload.cs
@@ -18,7 +18,7 @@ namespace Rynchodon.Update
 				if (mod.PublishedFileId == 363880940uL || mod.Name == "ARMS")
 				{
 					Logger.DebugLog("ARMS mod: FriendlyName: " + mod.FriendlyName + ", Name: " + mod.Name + ", Published ID: " + mod.PublishedFileId);
-					MySessionComponentBase component = Mods.FindModSessionComponent(mod.Name, "SteamShipped", "Notify");
+					MySessionComponentBase component = Mods.FindModSessionComponent(mod.Name, "SteamShipped", "SteamShipped.Notify");
 					if (component == null)
 					{
 						Logger.AlwaysLog($"Failed to find Session Component.", Logger.severity.ERROR);

--- a/Scripts/Utility/Mods.cs
+++ b/Scripts/Utility/Mods.cs
@@ -9,10 +9,9 @@ namespace Rynchodon
 {
 	public static class Mods
 	{
-		public static MySessionComponentBase FindModSessionComponent(string modName, string modProject, string componentClassName)
+		public static MySessionComponentBase FindModSessionComponent(string modName, string modScriptsFolder, string typeName)
 		{
-			string assemblyName = $"{modName}_{modProject}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
-			string typeName = $"{modProject}.{componentClassName}";
+			string assemblyName = $"{modName}_{modScriptsFolder}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
 
 			CachingDictionary<Type, MySessionComponentBase> sessionComponents = (CachingDictionary<Type, MySessionComponentBase>)
 				typeof(MySession).GetField("m_sessionComponents", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(MySession.Static);


### PR DESCRIPTION
Small change to the param use in `Mods.FindModSessionComponent()` to better reflect SE's namespace naming. 