### PR TITLE
build with SEPL instead of Load-ARMS

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "author": "Rynchodon",
+  "files": [
+    {
+      "source": "ARMS.dll"
+    },
+    {
+      "source": "..\\..\\..\\..\\README.md"
+    },
+    {
+      "source": "..\\..\\..\\..\\LICENSE"
+    }
+  ],
+  "release": {
+    "body": "Complete rewrite of radar code.\n\n  * Uses real radar formula\n  * Improved cooperation between radars\n  * Cooperation between jammers\n  * Sensors & Cameras can locate entities\n  * Removed radar from autopilot block\n\nas always, contains bug fixes",
+    "draft": false,
+    "prerelease": false
+  },
+  "repository": "ARMS"
+}


### PR DESCRIPTION
Changes `.build` scripts and provides a plugin config file to enable using SEPL for building plugins instead of Load-ARMS.

One thing to note here - the format for `release.body` in `plugin.json` really sucks because JSON doesn't allow multiline strings. I think an optimal solution here would be for SEPL to alternatively accept body content as an array of lines in `release.body_lines`.