### PR TITLE
UpdateManager imprvs

### DIFF
--- a/Scripts/Update/UpdateManager.cs
+++ b/Scripts/Update/UpdateManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -349,36 +349,6 @@ namespace Rynchodon.Update
 		}
 
 		private static UpdateManager Instance;
-
-		static UpdateManager()
-		{
-			string oldPath = Path.Combine(MyFileSystem.UserDataPath, "Storage", "363880940.sbm_Autopilot");
-			if (Directory.Exists(oldPath))
-			{
-				string newPath = Path.Combine(MyFileSystem.UserDataPath, "Storage", "ARMS");
-				if (Directory.Exists(newPath))
-				{
-					Logger.AlwaysLog("ARMS folder exists, data must be manually merged", Logger.severity.WARNING);
-					return;
-				}
-				Directory.Move(oldPath, newPath);
-				string AutopilotSettings = Path.Combine(newPath, "AutopilotSettings.txt");
-				if (File.Exists(AutopilotSettings))
-				{
-					string ServerSettings = Path.Combine(newPath, "ServerSettings.txt");
-					if (File.Exists(ServerSettings))
-					{
-						Logger.AlwaysLog("AutopilotSettings.txt and ServerSettings.txt both exist", Logger.severity.WARNING);
-						return;
-					}
-					File.Move(AutopilotSettings, ServerSettings);
-				}
-				else
-					Logger.AlwaysLog("No file at " + AutopilotSettings, Logger.severity.WARNING);
-			}
-			else
-				Logger.DebugLog("No directory at " + oldPath);
-		}
 
 		/// <param name="unregisterOnClosing">Leave as null if you plan on using Unregister at all.</param>
 		public static void Register(uint frequency, Action toInvoke, IMyEntity unregisterOnClosing = null)

--- a/Scripts/Update/UpdateManager.cs
+++ b/Scripts/Update/UpdateManager.cs
@@ -373,9 +373,6 @@ namespace Rynchodon.Update
 		private Dictionary<uint, List<Action>> UpdateRegistrar = new Dictionary<uint, List<Action>>();
 
 		private Dictionary<MyObjectBuilderType, List<Action<IMyCubeBlock>>> AllBlockScriptConstructors = new Dictionary<MyObjectBuilderType, List<Action<IMyCubeBlock>>>();
-		/// <summary>For scripts that use a separate condition to determine if they run for a block.</summary>
-		private List<Action<IMyCubeBlock>> EveryBlockScriptConstructors = new List<Action<IMyCubeBlock>>();
-		/// <summary>For scripts that run on IMyCharacter entities.</summary>
 		private List<Action<IMyCharacter>> CharacterScriptConstructors = new List<Action<IMyCharacter>>();
 		private List<Action<IMyCubeGrid>> GridScriptConstructors = new List<Action<IMyCubeGrid>>();
 
@@ -630,15 +627,6 @@ namespace Rynchodon.Update
 		}
 
 		/// <summary>
-		/// Register a constructor for every block, it is highly recommended to include a condition in the Action.
-		/// </summary>
-		/// <param name="constructor">constructor wrapped in an Action</param>
-		private void RegisterForEveryBlock(Action<IMyCubeBlock> constructor)
-		{
-			EveryBlockScriptConstructors.Add(constructor);
-		}
-
-		/// <summary>
 		/// register a constructor Action for a block
 		/// </summary>
 		/// <param name="objBuildType">type of block to create for</param>
@@ -765,16 +753,6 @@ namespace Rynchodon.Update
 							Log.AlwaysLog("Exception in " + typeId + " constructor: " + ex, Logger.severity.ERROR);
 							Logger.DebugNotify("Exception in " + typeId + " constructor", 10000, Logger.severity.ERROR);
 						}
-
-				if (EveryBlockScriptConstructors.Count > 0)
-					foreach (Action<IMyCubeBlock> constructor in EveryBlockScriptConstructors)
-						try { constructor.Invoke(fatblock); }
-						catch (Exception ex)
-						{
-							Log.AlwaysLog("Exception in every block constructor: " + ex, Logger.severity.ERROR);
-							Logger.DebugNotify("Exception in every block constructor", 10000, Logger.severity.ERROR);
-						}
-
 				return;
 			}
 		}

--- a/Scripts/Update/UpdateManager.cs
+++ b/Scripts/Update/UpdateManager.cs
@@ -791,8 +791,6 @@ namespace Rynchodon.Update
 			asGrid.OnClosing -= Grid_OnClosing;
 		}
 
-		#endregion
-
 		public override void SaveData()
 		{
 			AttributeFinder.InvokeMethodsWithAttribute<OnWorldSave>();
@@ -831,6 +829,9 @@ namespace Rynchodon.Update
 			ManagerStatus = Status.Terminated;
 		}
 
+		#endregion
+		#region Internal data access helpers
+
 		/// <summary>
 		/// Gets the constructor list mapped to a MyObjectBuilderType
 		/// </summary>
@@ -859,5 +860,6 @@ namespace Rynchodon.Update
 			return updates;
 		}
 
+		#endregion
 	}
 }

--- a/Scripts/Update/UpdateManager.cs
+++ b/Scripts/Update/UpdateManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -348,6 +348,7 @@ namespace Rynchodon.Update
 			RegisterForBlock(typeof(MyObjectBuilder_RemoteControl), act);
 		}
 
+		private static LockedDeque<Action> ExternalRegistrations = new LockedDeque<Action>();
 		private static UpdateManager Instance;
 
 		/// <param name="unregisterOnClosing">Leave as null if you plan on using Unregister at all.</param>
@@ -355,7 +356,7 @@ namespace Rynchodon.Update
 		{
 			if (Globals.WorldClosed)
 				return;
-			Instance.ExternalRegistrations.AddTail(() => {
+			ExternalRegistrations.AddTail(() => {
 				Instance.RegisterForUpdates(frequency, toInvoke, unregisterOnClosing);
 			});
 		}
@@ -364,7 +365,7 @@ namespace Rynchodon.Update
 		{
 			if (Globals.WorldClosed)
 				return;
-			Instance.ExternalRegistrations.AddTail(() => {
+			ExternalRegistrations.AddTail(() => {
 				Instance.UnRegisterForUpdates(frequency, toInvoke);
 			});
 		}
@@ -382,7 +383,6 @@ namespace Rynchodon.Update
 		private Status ManagerStatus = Status.Not_Initialized;
 
 		private LockedDeque<Action> AddRemoveActions = new LockedDeque<Action>();
-		private LockedDeque<Action> ExternalRegistrations = new LockedDeque<Action>();
 
 		private HashSet<long> CubeBlocks = new HashSet<long>();
 		private HashSet<long> Characters = new HashSet<long>();

--- a/Scripts/Update/UpdateManager.cs
+++ b/Scripts/Update/UpdateManager.cs
@@ -595,7 +595,6 @@ namespace Rynchodon.Update
 		}
 
 		#region Register
-
 		/// <summary>
 		/// register an Action for updates
 		/// </summary>
@@ -637,12 +636,7 @@ namespace Rynchodon.Update
 			//Log.DebugLog("Registered for block: " + objBuildType, "RegisterForBlock()", Logger.severity.DEBUG);
 			foreach (var block in CubeBlocks)
 				if (block.BlockDefinition.TypeId == objBuildType)
-					try { constructor.Invoke(block); }
-					catch (Exception ex)
-					{
-						Log.AlwaysLog("Exception in block constructor: " + ex, Logger.severity.ERROR);
-						Logger.DebugNotify("Exception in block constructor", 10000, Logger.severity.ERROR);
-					}
+					TryInvoke(() => constructor.Invoke(block), "block constructor");
 			BlockScriptConstructor(objBuildType).Add(constructor);
 		}
 
@@ -660,12 +654,7 @@ namespace Rynchodon.Update
 		{
 			//Log.DebugLog("Registered for character", "RegisterForCharacter()", Logger.severity.DEBUG);
 			foreach (var character in Characters)
-				try { constructor.Invoke(character); }
-				catch (Exception ex)
-				{
-					Log.AlwaysLog("Exception in character constructor: " + ex, Logger.severity.ERROR);
-					Logger.DebugNotify("Exception in character constructor", 10000, Logger.severity.ERROR);
-				}
+				TryInvoke(() => constructor.Invoke(character), "character constructor");
 			CharacterScriptConstructors.Add(constructor);
 		}
 
@@ -677,12 +666,7 @@ namespace Rynchodon.Update
 		{
 			//Log.DebugLog("Registered for grid", "RegisterForGrid()", Logger.severity.DEBUG);
 			foreach (var grid in CubeGrids)
-				try { constructor.Invoke(grid); }
-				catch (Exception ex)
-				{
-					Log.AlwaysLog("Exception in grid constructor: " + ex, Logger.severity.ERROR);
-					Logger.DebugNotify("Exception in grid constructor", 10000, Logger.severity.ERROR);
-				}
+				TryInvoke(() => constructor.Invoke(grid), "grid constructor");
 			GridScriptConstructors.Add(constructor);
 		}
 
@@ -722,12 +706,7 @@ namespace Rynchodon.Update
 				asGrid.OnClosing += Grid_OnClosing;
 
 				foreach (var constructor in GridScriptConstructors)
-					try { constructor.Invoke(asGrid); }
-					catch (Exception ex)
-					{
-						Log.AlwaysLog("Exception in grid constructor: " + ex, Logger.severity.ERROR);
-						Logger.DebugNotify("Exception in grid constructor", 10000, Logger.severity.ERROR);
-					}
+					TryInvoke(() => constructor.Invoke(asGrid), "grid constructor");
 				return;
 			}
 			IMyCharacter asCharacter = entity as IMyCharacter;
@@ -742,12 +721,7 @@ namespace Rynchodon.Update
 
 				Log.DebugLog("adding character: " + entity.getBestName());
 				foreach (var constructor in CharacterScriptConstructors)
-					try { constructor.Invoke(asCharacter); }
-					catch (Exception ex)
-					{
-						Log.AlwaysLog("Exception in character constructor: " + ex, Logger.severity.ERROR);
-						Logger.DebugNotify("Exception in character constructor", 10000, Logger.severity.ERROR);
-					}
+					TryInvoke(() => constructor.Invoke(asCharacter), "character constructor");
 				return;
 			}
 		}
@@ -776,12 +750,7 @@ namespace Rynchodon.Update
 
 				if (AllBlockScriptConstructors.ContainsKey(typeId))
 					foreach (Action<IMyCubeBlock> constructor in BlockScriptConstructor(typeId))
-						try { constructor.Invoke(fatblock); }
-						catch (Exception ex)
-						{
-							Log.AlwaysLog("Exception in " + typeId + " constructor: " + ex, Logger.severity.ERROR);
-							Logger.DebugNotify("Exception in " + typeId + " constructor", 10000, Logger.severity.ERROR);
-						}
+						TryInvoke(() => constructor.Invoke(fatblock), typeId + " constructor");
 				return;
 			}
 		}
@@ -865,6 +834,20 @@ namespace Rynchodon.Update
 				UpdateRegistrar.Add(frequency, updates);
 			}
 			return updates;
+		}
+
+		private bool TryInvoke(Action action, string context)
+		{
+			try {
+				action.Invoke();
+				return true;
+			}
+			catch (Exception error)
+			{
+				Log.AlwaysLog($"Error running action for {context}: {error}", Logger.severity.ERROR);
+				Logger.DebugNotify($"Error running action for {context}.", 10000, Logger.severity.ERROR);
+				return false;
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
Includes various improvements to `UpdateManager`:
* Removed the static constructor that checks for settings in an old dir and moves them to the new dir. This is 7 months old, and even if someone somehow had settings from back then that were still valid, the impact would be small.
* Moves ExternalRegistrations to a static variable so it can be used before the instance is constructed
* Small fixes to regions
* Removes unused EveryBlockScriptConstructors
* Tracks existing entities and passes them to newly registered constructors
* Moves some repeated logging behavior to TryInvoke()

These changes came around while I was working on update components, which are still in progress.

@Rynchodon please review when able. Happy to make any requested changes.
